### PR TITLE
Deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 2. Rename `.env.example` to `.env` and fill `CHALLONGE_API_KEY`
 
 ### Starting the server
-`npm run serve` will start the GraphQL server in the port `6678`, overridable with the `SERVER_PORT` environment variable
+`npm start` will start the GraphQL server in the port `6678`, overridable with the `SERVER_PORT` environment variable
 
 ### Starting the client
-`npm start`
+`npm run client:start`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "react-tap-event-plugin": "^2.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "node server",
     "serve": "nodemon server",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "client:start": "react-scripts start",
+    "client:build": "react-scripts build",
+    "client:test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "proxy": "https://api.challonge.com/v1",

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,10 @@ import './index.css';
 import ApolloClient, { createNetworkInterface } from 'apollo-client';
 import { ApolloProvider } from 'react-apollo';
 
+const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:6678/graphql';
+
 const client = new ApolloClient({
-  networkInterface: createNetworkInterface({ uri: 'http://localhost:6678/graphql' }),
+  networkInterface: createNetworkInterface({ uri: backendUrl }),
 });
 
 ReactDOM.render(


### PR DESCRIPTION
Cliente: https://build-uygfnkunfw.now.sh/
Servidor: https://challonge-dashboard-ccudmfikny.now.sh/graphiql

Igual para lo que queremos hacer no es muy práctico now, porque cuando deployemos el server tenemos que rebuildear y volver a deployar el cliente apuntando a la URL nueva. Pero quería tener una versión online para que no muera la manija 💥 :manija:

En algún momento configuramos un Digital Ocean y chau.