### PR TITLE
Deploy with `shipitjs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ coverage
 # production
 build
 
+# deploy
+deploy
+
 # misc
 .DS_Store
 .env

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "devDependencies": {
     "nodemon": "^1.11.0",
-    "react-scripts": "0.8.4"
+    "react-scripts": "0.8.4",
+    "shipit": "^1.0.2",
+    "shipit-cli": "^2.0.0",
+    "shipit-deploy": "^2.4.0"
   },
   "dependencies": {
     "apollo-client": "^0.7.1",
@@ -30,7 +33,8 @@
     "client:start": "react-scripts start",
     "client:build": "react-scripts build",
     "client:test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy:prod": "shipit prod deploy"
   },
   "proxy": "https://api.challonge.com/v1",
   "engineStrict": true,

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -1,0 +1,30 @@
+module.exports = shipit => {
+  require('shipit-deploy')(shipit)
+
+  const localDeployDir = './deploy'
+  const prodServerIp = '192.241.223.201'
+
+  shipit.initConfig({
+    default: {
+      workspace: localDeployDir,
+      deployTo: './dashboard-deploys',
+      repositoryUrl: 'https://github.com/julioolvr/challonge-dashboard',
+      ignores: ['.git', 'node_modules', '.env'],
+      keepReleases: 5
+    },
+
+    prod: {
+      servers: `deploy@${prodServerIp}`
+    }
+  })
+
+  shipit.blTask('build', () => {
+    // TODO: This should decide the IP based on the environment being deployed to,
+    // it will matter if we eventually have more than one.
+    return shipit.local(`REACT_APP_BACKEND_URL=http://${prodServerIp}/api/graphql npm run client:build`, { cwd: localDeployDir })
+  })
+
+  shipit.on('fetched', () => {
+    return shipit.start('build')
+  })
+}


### PR DESCRIPTION
Hay un par de cosas que considero crotas pero creo que por ahora va.

En el server los deploys quedan en `/home/deploy/dashboard-deploys`. El server está en `/home/deploy/challonge-dashboard` y el cliente en `/var/www/superliga/html`, ambos son symlinks a los directorios correspondientes en `/home/deploy/dashboard-deploys/current`. Medio croto todo, pero funciona.

Me gustaría bancar el merge hasta que esté #11 así hacemos la prueba de fuego.

BTW, qué verga la documentación de las librerías de hoy en día. Me sorprende que shipitjs sea _la posta_.